### PR TITLE
Rename 'abstract' field UI to 'talk outline'

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -172,10 +172,10 @@ class ProposalDecorator < ApplicationDecorator
     form.input :speaker
   end
 
-  def abstract_input(form, tooltip = "Proposal Abstract")
-    form.input :abstract,
+  def abstract_input(form, tooltip = "Talk Outline")
+    form.input :abstract, label: "Talk Outline",
       maxlength: 1005, input_html: { class: 'watched js-maxlength-alert', rows: 5 },
-      hint: 'A concise, engaging description for the public program. Limited to 600 characters.'#, popover_icon: { content: tooltip }
+      hint: 'This is the place to outline the specifics of your talk: what topics will you cover, if you\'ll have any special elements (i.e., code samples, video samples, etc.), what you\'d like the audience to take away from your talk, and how you\'d like them to feel afterwards.'#, popover_icon: { content: tooltip }
   end
 
   def standalone_track_select(tooltip)

--- a/app/helpers/proposal_helper.rb
+++ b/app/helpers/proposal_helper.rb
@@ -33,7 +33,7 @@ module ProposalHelper
   end
 
   def abstract_tooltip
-    "A concise, engaging description for the public program. Limited to 600 characters."
+    "This is the place to outline the specifics of your talk: what topics will you cover, if you\'ll have any special elements (i.e., code samples, video samples, etc.), what you\'d like the audience to take away from your talk, and how you\'d like them to feel afterwards."
   end
 
   def details_tooltip

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -103,7 +103,7 @@ class TimeSlotModal extends Component {
           <p>{tracks.find(track => track.id === sessionSelected.track_id || 'No track').name}</p>
         </label>
         <label>
-          Abstract:
+          Talk Outline:
           <p>{sessionSelected.abstract}</p>
         </label>
         <label>

--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -18,7 +18,7 @@
           %th Event
           %th Title
           %th Status
-          %th Abstract
+          %th Talk Outline
       %tbody
         - user.proposals.to_a.group_by(&:event).each do |event, talks|
           - talks.each do |proposal|

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,5 +1,5 @@
 .proposal-section
-  %h3.control-label Abstract
+  %h3.control-label Talk Outline
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
 

--- a/app/views/staff/grids/program_sessions/_show_dialog.html.haml
+++ b/app/views/staff/grids/program_sessions/_show_dialog.html.haml
@@ -9,7 +9,7 @@
         - {'Format': 'session_format_name',
             'Theme': 'track_name',
             'Presenter':'speaker_names',
-            'Abstract': 'abstract',
+            'Talk Outline': 'abstract',
             'Suggested Duration': 'suggested_duration',
           }.each do |attr, getter_method|
           - value = session.try(getter_method)

--- a/app/views/staff/grids/time_slots/_form.html.haml
+++ b/app/views/staff/grids/time_slots/_form.html.haml
@@ -11,7 +11,7 @@
     %strong Presenter:
     %p.speaker= time_slot.session_presenter
   .session-meta-item
-    %strong Abstract:
+    %strong Talk Outline:
     %p.abstract= time_slot.session_description
   .session-meta-item
     %strong Suggested duration:

--- a/app/views/staff/program_sessions/_form.html.haml
+++ b/app/views/staff/program_sessions/_form.html.haml
@@ -6,7 +6,7 @@
       = f.association :track, as: :select, collection: current_event.tracks, label: "Theme", include_blank: true
       - unless @program_session.new_record?
         = f.input :state, as: :select, collection: session_states_collection, label: "State", required: true
-      = f.input :abstract, maxlength: 1205, input_html: { class: 'watched js-maxlength-alert', rows: 5 }
+      = f.input :abstract, maxlength: 1205, input_html: { class: 'watched js-maxlength-alert', rows: 5 }, label: "Talk Outline"
       = f.label :video_url
       = f.text_field :video_url, class: "form-control"
       = f.label :slides_url

--- a/app/views/staff/program_sessions/show.html.haml
+++ b/app/views/staff/program_sessions/show.html.haml
@@ -39,7 +39,7 @@
         %h3.control-label Theme
         %p #{program_session.track_name}
       .program-session-item
-        %h3.control-label Abstract
+        %h3.control-label Talk Outline
         .markdown{ data: { 'field-id' => 'program_session_abstract' } }
           = program_session.abstract_markdown
       .program-session-item

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -1,5 +1,5 @@
 .proposal-section
-  %h3.control-label Abstract
+  %h3.control-label Talk Outline
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
 

--- a/app/views/staff/time_slots/_form.html.haml
+++ b/app/views/staff/time_slots/_form.html.haml
@@ -20,7 +20,7 @@
     %strong Presenter:
     %p.speaker= time_slot.session_presenter
   .session-meta-item
-    %strong Abstract:
+    %strong Talk Outline:
     %p.abstract= time_slot.session_description
   .session-meta-item
     %strong Suggested duration:

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -11,7 +11,7 @@ feature "Proposals" do
 
   let(:create_proposal) do
     fill_in 'Title', with: "General Principles Derived by Magic from My Personal Experience"
-    fill_in 'Abstract', with: "Because certain things happened to me, they will happen in just the same manner to everyone."
+    fill_in 'Talk Outline', with: "Because certain things happened to me, they will happen in just the same manner to everyone."
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am awesome."
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
@@ -56,7 +56,7 @@ feature "Proposals" do
       end
 
       it "shows Abstract validation if blank on submit" do
-        expect(page).to have_text("Abstract *\ncan't be blank")
+        expect(page).to have_text("Talk Outline *\ncan't be blank")
       end
     end
 


### PR DESCRIPTION
This PR renames the 'Abstract' field to 'Talk Abstract'. This is purely a UI level change: none of the underlying data structures have been changed.

<img width="1059" alt="CleanShot 2021-06-07 at 15 05 30@2x" src="https://user-images.githubusercontent.com/37842/121083234-cb0b2000-c7a4-11eb-9c33-2bfb82210f18.png">
<img width="551" alt="CleanShot 2021-06-07 at 15 06 24@2x" src="https://user-images.githubusercontent.com/37842/121083241-ccd4e380-c7a4-11eb-8a16-93c239b6f929.png">
<img width="777" alt="CleanShot 2021-06-07 at 15 06 41@2x" src="https://user-images.githubusercontent.com/37842/121083245-ce9ea700-c7a4-11eb-814c-96cccdad0bc8.png">


Closes #2 