### PR TITLE
Rename 'Details' ui field to 'Problem'

### DIFF
--- a/app/helpers/proposal_helper.rb
+++ b/app/helpers/proposal_helper.rb
@@ -37,7 +37,7 @@ module ProposalHelper
   end
 
   def details_tooltip
-    "Include any pertinent details such as outlines, outcomes or intended audience."
+    "What problem is your talk solving?"
   end
 
   def pitch_tooltip

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -6,7 +6,7 @@
 %h2.fieldset-legend For Review Committee
 
 .proposal-section
-  %h3.control-label Details
+  %h3.control-label Problem
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = proposal.details_markdown
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -41,8 +41,8 @@
   %p
     This content will <strong> only</strong> be visible to the review committee.
 
-  = f.input :details, input_html: { class: 'watched', rows: 5 },
-    hint: 'Include any pertinent details such as outlines, outcomes or intended audience.'#, popover_icon: { content: details_tooltip }
+  = f.input :details, input_html: { class: 'watched', rows: 5 }, label: 'Problem',
+    hint: 'What problem is your talk solving?'#, popover_icon: { content: details_tooltip }
 
   = f.input :pitch, input_html: { class: 'watched', rows: 5 },
     hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.'#, popover_icon: { content: pitch_tooltip }

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -6,7 +6,7 @@
 %h2.fieldset-legend For Review Committee
 
 .proposal-section
-  %h3.control-label Details
+  %h3.control-label Problem
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = markdown(proposal.details)
 

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -14,7 +14,7 @@ feature "Proposals" do
     fill_in 'Abstract', with: "Because certain things happened to me, they will happen in just the same manner to everyone."
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am awesome."
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
-    fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
+    fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     select 'Only format', from: 'Session format'
     click_button 'Submit'
   end
@@ -22,7 +22,7 @@ feature "Proposals" do
   let(:create_invalid_proposal) do
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am a great speaker!."
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
-    fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
+    fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     click_button 'Submit'
   end
 


### PR DESCRIPTION
Another strictly UI level change, this renames the 'Details' field viewed by the reviewing committee to 'Problems. No data structures were changed.

<img width="578" alt="CleanShot 2021-06-07 at 21 18 05@2x" src="https://user-images.githubusercontent.com/37842/121112525-2a355880-c7d6-11eb-9f6a-d611bc44d9e0.png">
<img width="377" alt="CleanShot 2021-06-07 at 21 18 12@2x" src="https://user-images.githubusercontent.com/37842/121112537-2bff1c00-c7d6-11eb-900a-4b929abaf570.png">
<img width="519" alt="CleanShot 2021-06-07 at 21 18 28@2x" src="https://user-images.githubusercontent.com/37842/121112539-2d304900-c7d6-11eb-93d2-c233a9058ef5.png">

Closes #3 