### PR TITLE
Rename 'pitch' to 'fit'

### DIFF
--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -11,7 +11,7 @@
     = proposal.details_markdown
 
 .proposal-section
-  %h3.control-label Pitch
+  %h3.control-label Fit
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch_markdown
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -44,8 +44,8 @@
   = f.input :details, input_html: { class: 'watched', rows: 5 }, label: 'Problem',
     hint: 'What problem is your talk solving?'#, popover_icon: { content: details_tooltip }
 
-  = f.input :pitch, input_html: { class: 'watched', rows: 5 },
-    hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.'#, popover_icon: { content: pitch_tooltip }
+  = f.input :pitch, input_html: { class: 'watched', rows: 5 }, label: 'Fit',
+    hint: 'Explain why you’re the best person to give this talk. This is less about expertise (which is not a requirement), but more about the relationship between the talk and the speaker, and finding a good fit. Feel free to include your passion, past experience, previous roles, etc.'#, popover_icon: { content: pitch_tooltip }
 
 - if event.custom_fields.any?
   - event.custom_fields.each do |custom_field|

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -11,7 +11,7 @@
     = markdown(proposal.details)
 
 .proposal-section
-  %h3.control-label Pitch
+  %h3.control-label Fit
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     = markdown(proposal.pitch)
 

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -13,7 +13,7 @@ feature "Proposals" do
     fill_in 'Title', with: "General Principles Derived by Magic from My Personal Experience"
     fill_in 'Talk Outline', with: "Because certain things happened to me, they will happen in just the same manner to everyone."
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am awesome."
-    fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
+    fill_in 'Fit', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     select 'Only format', from: 'Session format'
     click_button 'Submit'
@@ -21,7 +21,7 @@ feature "Proposals" do
 
   let(:create_invalid_proposal) do
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am a great speaker!."
-    fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
+    fill_in 'Fit', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     click_button 'Submit'
   end


### PR DESCRIPTION
It's another UI level change! This time we're renaming 'Pitch' to 'Fit' at the UI level: no data or structure changes. 

<img width="1043" alt="CleanShot 2021-06-08 at 10 00 59@2x" src="https://user-images.githubusercontent.com/37842/121210874-a749e780-c841-11eb-82bb-14c5d3e5c4cf.png">
<img width="320" alt="CleanShot 2021-06-08 at 10 01 28@2x" src="https://user-images.githubusercontent.com/37842/121210880-a87b1480-c841-11eb-9cae-56c789681ed5.png">
<img width="518" alt="CleanShot 2021-06-08 at 10 01 51@2x" src="https://user-images.githubusercontent.com/37842/121210885-a9ac4180-c841-11eb-8c0c-db6d3b632545.png">


Closes #4 