### PR TITLE
Add dev and codenewbie username fields to speaker

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -144,7 +144,7 @@ class ProposalsController < ApplicationController
     params.require(:proposal).permit(:title, {tags: []}, :session_format_id, :track_id, :abstract, :details, :pitch, :suggested_theme, 
                                      custom_fields: @event.custom_fields,
                                      comments_attributes: [:body, :proposal_id, :user_id],
-                                     speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker])
+                                     speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker, :dev_username, :codenewbie_username])
   end
 
   def notes_params

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -9,6 +9,10 @@
 
     = speaker_fields.input :bio, disabled: speaker.user!=current_user, maxlength: :lookup, input_html: { value: speaker.bio, rows: 4 }, hint: "Your bio should be short, no longer than 500 characters. It's related to why you're speaking about this topic."#, popover_icon: { content: bio_tooltip }
 
+    = speaker_fields.input :dev_username, input_html: { value: speaker.dev_username}, hint: "What is your DEV username, if you have one"
+
+    = speaker_fields.input :codenewbie_username, input_html: { value: speaker.codenewbie_username}, hint: "What is your CodeNewbie Community username, if you have one"
+
     %p
       These demographic fields are optional and are intended to help us achieve a better understanding of our speaker demographic as we aim to diversify our program. These details will not be shared with the program committee and will only be available to us after talks are selected.
 

--- a/app/views/speakers/_speaker.html.haml
+++ b/app/views/speakers/_speaker.html.haml
@@ -10,6 +10,12 @@
 
   = simple_format speaker.bio
 
+  %strong DEV username:
+  = simple_format speaker.dev_username
+
+  %strong CodeNewbie username:
+  = simple_format speaker.codenewbie_username
+
   %strong First time speaker:
   = simple_format boolean_to_words(speaker.first_time_speaker)
 

--- a/app/views/staff/speakers/show.html.haml
+++ b/app/views/staff/speakers/show.html.haml
@@ -39,6 +39,12 @@
         %h3.control-label Bio
         %p= @speaker.bio
       .program-session-item
+        %h3.control-label DEV username
+        %p= @speaker.dev_username
+      .program-session-item
+        %h3.control-label CodeNewbie username
+        %p= @speaker.codenewbie_username
+      .program-session-item
         %h3.control-label First time speaker?
         %p= boolean_to_words(@speaker.first_time_speaker)
       .program-session-item

--- a/db/migrate/20210608211809_add_dev_and_codenewbie_usernames_to_speaker.rb
+++ b/db/migrate/20210608211809_add_dev_and_codenewbie_usernames_to_speaker.rb
@@ -1,0 +1,6 @@
+class AddDevAndCodenewbieUsernamesToSpeaker < ActiveRecord::Migration[6.1]
+  def change
+    add_column :speakers, :dev_username, :string
+    add_column :speakers, :codenewbie_username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_141923) do
+ActiveRecord::Schema.define(version: 2021_06_08_211809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,6 +164,8 @@ ActiveRecord::Schema.define(version: 2021_06_04_141923) do
     t.string "ethnicity"
     t.boolean "first_time_speaker"
     t.string "pronouns"
+    t.string "dev_username"
+    t.string "codenewbie_username"
     t.index ["event_id"], name: "index_speakers_on_event_id"
     t.index ["program_session_id"], name: "index_speakers_on_program_session_id"
     t.index ["proposal_id"], name: "index_speakers_on_proposal_id"

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
     user
     event { Event.first || FactoryBot.create(:event) }
     bio { "Speaker bio" }
+    dev_username { Faker::Internet.username }
+    codenewbie_username { Faker::Internet.username }
 
     trait :with_name do
       speaker_name


### PR DESCRIPTION
Adds fields 'DEV Username' and 'CodeNewbie Username' to the Speaker section of the proposal form. This information is viewable/editable by the proposal author, but not displayed to the reviewers.

Database fields were added to the `speakers` table, and fields added to the proposal form.

<img width="573" alt="CleanShot 2021-06-09 at 09 26 56@2x" src="https://user-images.githubusercontent.com/37842/121377083-b2674b00-c907-11eb-9ab9-eb265bcaf66a.png">
<img width="287" alt="CleanShot 2021-06-09 at 09 27 09@2x" src="https://user-images.githubusercontent.com/37842/121377088-b3987800-c907-11eb-9de3-bed71aad4126.png">


Closes #5 
Closes #6 