### PR TITLE
Allow comments to be deleted

### DIFF
--- a/app/assets/stylesheets/modules/_widgets.scss
+++ b/app/assets/stylesheets/modules/_widgets.scss
@@ -168,3 +168,12 @@
     background: lighten($brand-info, 45%);
   }
 }
+
+.deleted_comment {
+  background-color:lightblue;
+}
+
+.trash-wrapper{
+  font-size: 14px;
+  padding-left: 10px;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -19,6 +19,18 @@ class CommentsController < ApplicationController
     redirect_back fallback_location: event_proposal_path(@proposal.event, uuid: @proposal)
   end
 
+  def destroy
+    @comment = Comment.find(params.require(:id))
+
+    authorize @comment, :mark_as_deleted!, policy_class: CommentPolicy
+
+    unless @comment.mark_as_deleted!
+      flash[:danger] = "Couldn't delete comment: #{@comment.errors.full_messages.to_sentence}"
+    end
+
+    redirect_back fallback_location: event_proposal_path(@comment.proposal.event, uuid: @comment.proposal)
+  end
+
   private
   def comment_type
     @comment_type ||= valid_comment_types.find{|t| t==params[:type]} || 'PublicComment'
@@ -29,6 +41,6 @@ class CommentsController < ApplicationController
   end
 
   def comment_params
-    params.require(comment_type.underscore).permit(:body, :proposal_id)
+    params.require(comment_type.underscore).permit(:body, :proposal_id, :comment_id)
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -20,4 +20,9 @@ module CommentsHelper
   def internal?(comment)
     comment.type == "InternalComment"
   end
+
+  def show_destroy_comment?(comment)
+    comment.user == current_user && !comment.deleted?
+  end
+
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,10 @@ class Comment < ApplicationRecord
     type == "PublicComment"
   end
 
+  def mark_as_deleted!
+    update_attribute(:deleted, true)
+  end
+
 end
 
 # == Schema Information

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,7 @@
+class CommentPolicy < ApplicationPolicy
+
+  def mark_as_deleted!
+    @record.user.id == @user.id
+  end
+
+end

--- a/app/views/proposals/_comments.html.haml
+++ b/app/views/proposals/_comments.html.haml
@@ -7,8 +7,18 @@
             %p.name
               = commenter_name(comment)
             %span.time #{comment.created_at.to_s(:day_at_time)}
+
+            - if show_destroy_comment?(comment)
+              %span.trash-wrapper
+                = link_to(comment_path(comment), :method=>:delete) do
+                  %i.fa.fa-trash
+
         .text
-          =markdown(comment.body)
+          - if comment.deleted?
+            %span.deleted_comment Comment was deleted
+          - else
+            =markdown(comment.body)
+
 
 = form_for comments.new do |f|
   = f.hidden_field :proposal_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
   resource :public_comments, only: [:create], controller: :comments, type: 'PublicComment'
   resource :internal_comments, only: [:create], controller: :comments, type: 'InternalComment'
 
+  resources :comments, only: [:destroy]
+
   resources :speakers, only: [:destroy]
   resources :events, only: [:index]
 

--- a/db/migrate/20210629220418_add_deleted_to_comments.rb
+++ b/db/migrate/20210629220418_add_deleted_to_comments.rb
@@ -1,0 +1,5 @@
+class AddDeletedToComments < ActiveRecord::Migration[6.1]
+  def change
+    add_column :comments, :deleted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_09_145622) do
+ActiveRecord::Schema.define(version: 2021_06_29_220418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2021_06_09_145622) do
     t.string "type"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "deleted", default: false, null: false
     t.index ["proposal_id"], name: "index_comments_on_proposal_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end


### PR DESCRIPTION
Closes https://github.com/forem/cfp-app/issues/28

Gives users the ability to delete their own comments on proposals and reviews. Note that a user is only allowed to delete their own comments. Comments aren't really deleted from the database: instead we display a notice that the comment was deleted to all views. 

Example display of a speaker's comments on the proposal page when logged in as the speaker/proposal creator:

<img width="429" src="https://user-images.githubusercontent.com/37842/124039190-0c6ba580-d9c8-11eb-9b73-51564b0fff4e.png">

Example display of a reviewer's comments on the proposal page when logged in as the speaker/proposal creator:

<img width="429" alt="CleanShot 2021-06-30 at 17 25 41@2x" src="https://user-images.githubusercontent.com/37842/124039257-36bd6300-d9c8-11eb-9786-abbe0c3f4d0e.png">

No funny business: we check server side to make sure a user can only delete their own comments:

<img width="771" alt="CleanShot 2021-06-30 at 17 27 32@2x" src="https://user-images.githubusercontent.com/37842/124039436-87cd5700-d9c8-11eb-943e-aa9969c7ce3e.png">





