### PR TITLE
Hide Research, add Talk Type to database

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -142,7 +142,7 @@ class ProposalsController < ApplicationController
 
   def proposal_params
     params.require(:proposal).permit(:title, {tags: []}, :session_format_id, :track_id, :abstract, :details, :pitch, :suggested_theme, 
-                                     :research, :location_and_time_zone, :equipment_requirements, :accessibility_requirements, :video_voice_recording_permission, 
+                                     :location_and_time_zone, :equipment_requirements, :accessibility_requirements, :video_voice_recording_permission, 
                                      custom_fields: @event.custom_fields,
                                      comments_attributes: [:body, :proposal_id, :user_id],
                                      speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker, :dev_username, :codenewbie_username])

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -142,7 +142,7 @@ class ProposalsController < ApplicationController
 
   def proposal_params
     params.require(:proposal).permit(:title, {tags: []}, :session_format_id, :track_id, :abstract, :details, :pitch, :suggested_theme, 
-                                     :location_and_time_zone, :equipment_requirements, :accessibility_requirements, :video_voice_recording_permission, 
+                                     :talk_type, :location_and_time_zone, :equipment_requirements, :accessibility_requirements, :video_voice_recording_permission, 
                                      custom_fields: @event.custom_fields,
                                      comments_attributes: [:body, :proposal_id, :user_id],
                                      speakers_attributes: [:bio, :id, :age_range, :pronouns, :ethnicity, :first_time_speaker, :dev_username, :codenewbie_username])

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -20,6 +20,12 @@ class Proposal < ApplicationRecord
   belongs_to :session_format
   belongs_to :track
 
+  TALK_TYPES = [
+    ANECDOTAL = 'Anecdotal/Descriptive',
+    RESEARCH = 'Research-Based/Technical',
+    HYBRID = 'Hybrid'
+  ].freeze
+
   validates :title, :abstract, :session_format, presence: true
   validate :abstract_length
   validates :title, length: { maximum: 60 }

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -27,7 +27,7 @@ class Proposal < ApplicationRecord
   validates_inclusion_of :state, in: FINAL_STATES, allow_nil: false, message: "'%{value}' not a confirmable state.",
                                  if: :confirmed_at_changed?
 
-  validates :research, :location_and_time_zone, :equipment_requirements, :accessibility_requirements, presence: true
+  validates :location_and_time_zone, :equipment_requirements, :accessibility_requirements, presence: true
   validates :video_voice_recording_permission, acceptance: true
 
   serialize :last_change

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -15,12 +15,10 @@
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch_markdown
 
-
-/
-  .proposal-section
-    %h3.control-label Talk Type
-    .markdown{ data: { 'field-id' => 'talk_type' } }
-      = markdown(proposal.talk_type) 
+.proposal-section
+  %h3.control-label Talk Type
+  .markdown{ data: { 'field-id' => 'talk_type' } }
+    = markdown(proposal.talk_type) 
 
 .proposal-section
   %h3.control-label Location and Time zone

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -15,10 +15,12 @@
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch_markdown
 
-.proposal-section
-  %h3.control-label Research
-  .markdown{ data: { 'field-id' => 'research' } }
-    = markdown(proposal.research) 
+
+/
+  .proposal-section
+    %h3.control-label Talk Type
+    .markdown{ data: { 'field-id' => 'talk_type' } }
+      = markdown(proposal.talk_type) 
 
 .proposal-section
   %h3.control-label Location and Time zone

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -47,9 +47,8 @@
   = f.input :pitch, input_html: { class: 'watched', rows: 5 }, label: 'Fit',
     hint: 'Explain why you’re the best person to give this talk. This is less about expertise (which is not a requirement), but more about the relationship between the talk and the speaker, and finding a good fit. Feel free to include your passion, past experience, previous roles, etc.'#, popover_icon: { content: pitch_tooltip }
 
-  /
-    = f.input :talk_type, required: true,
-      hint: "Please let us know which category you most see your proposed talk fitting in. Note: we don't favor one type of talk over others, but hope to have a good mix"
+  = f.input :talk_type, collection: Proposal::TALK_TYPES, required: true,
+    hint: "Please let us know which category you most see your proposed talk fitting in. Note: we don't favor one type of talk over others, but hope to have a good mix"
 
   = f.input :location_and_time_zone, required: true
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -47,8 +47,9 @@
   = f.input :pitch, input_html: { class: 'watched', rows: 5 }, label: 'Fit',
     hint: 'Explain why you’re the best person to give this talk. This is less about expertise (which is not a requirement), but more about the relationship between the talk and the speaker, and finding a good fit. Feel free to include your passion, past experience, previous roles, etc.'#, popover_icon: { content: pitch_tooltip }
 
-  = f.input :research, input_html: { class: 'watched', rows: 5 }, required: true,
-    hint: "What resources and research do you plan to include in your talk, if any? (i.e., interviews, reports, primary sources, academic journals, etc.)"
+  /
+    = f.input :talk_type, required: true,
+      hint: "Please let us know which category you most see your proposed talk fitting in. Note: we don't favor one type of talk over others, but hope to have a good mix"
 
   = f.input :location_and_time_zone, required: true
 
@@ -60,7 +61,7 @@
 
   = f.input :video_voice_recording_permission, required: true, label: 'Video and Voice Recording Permission',
     as: :boolean, boolean_style: :inline, 
-    hint: "Each CodeLand 2021 talk will be submitted as a 15-minute pre-recorded video. We may also invite you to participate in a moderated live panel over video conference. Please check here to confirm that, if accepted, you are committing to sending us a pre-recorded 15-minute video of your talk and to possibly participating in a live panel over video conference."
+    hint: "Each CodeLand talk will be submitted as a 15-minute pre-recorded video. We may also invite you to participate in a moderated live panel over video conference. Please check here to confirm that, if accepted, you are committing to sending us a pre-recorded 15-minute video of your talk and to possibly participating in a live panel over video conference."
 
 - if event.custom_fields.any?
   - event.custom_fields.each do |custom_field|

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -15,7 +15,6 @@
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     = markdown(proposal.pitch)
 
-/
   .proposal-section
     %h3.control-label Talk Type
     .markdown{ data: { 'field-id' => 'talk_type' } }

--- a/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
+++ b/app/views/staff/proposal_reviews/_reviewer_contents.html.haml
@@ -15,10 +15,11 @@
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     = markdown(proposal.pitch)
 
-.proposal-section
-  %h3.control-label Research
-  .markdown{ data: { 'field-id' => 'research' } }
-    = markdown(proposal.research) 
+/
+  .proposal-section
+    %h3.control-label Talk Type
+    .markdown{ data: { 'field-id' => 'talk_type' } }
+      = markdown(proposal.talk_type) 
 
 .proposal-section
   %h3.control-label Location and Time zone

--- a/db/migrate/20220217194916_change_research_to_be_nullable.rb
+++ b/db/migrate/20220217194916_change_research_to_be_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeResearchToBeNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :proposals, :research, true
+  end
+end

--- a/db/migrate/20220217195116_add_proposal_talk_type.rb
+++ b/db/migrate/20220217195116_add_proposal_talk_type.rb
@@ -1,0 +1,5 @@
+class AddProposalTalkType < ActiveRecord::Migration[6.1]
+  def change
+    add_column :proposals, :talk_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_29_220418) do
+ActiveRecord::Schema.define(version: 2022_02_17_195116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,11 +110,12 @@ ActiveRecord::Schema.define(version: 2021_06_29_220418) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "suggested_theme"
-    t.text "research", null: false
+    t.text "research"
     t.string "location_and_time_zone", null: false
     t.text "equipment_requirements", null: false
     t.text "accessibility_requirements", null: false
     t.boolean "video_voice_recording_permission", default: false, null: false
+    t.string "talk_type"
     t.index ["event_id"], name: "index_proposals_on_event_id"
     t.index ["session_format_id"], name: "index_proposals_on_session_format_id"
     t.index ["track_id"], name: "index_proposals_on_track_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,7 +174,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -191,7 +191,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -209,7 +209,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -227,7 +227,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -245,7 +245,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -263,7 +263,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -349,7 +349,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -368,7 +368,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
     p.abstract = Faker::Hipster.sentence
     p.details = Faker::Hacker.say_something_smart
     p.pitch = Faker::Superhero.power
-    p.research = Faker::Lorem.sentence
+    p.talk_type = Proposal::TALK_TYPES.sample
     p.location_and_time_zone = Time.zone_default
     p.equipment_requirements = Faker::Lorem.sentence
     p.accessibility_requirements = Faker::Lorem.sentence
@@ -543,7 +543,7 @@ If you are on the cutting edge with savvy scheduling skills, we want you!
         abstract: Faker::Hipster.sentence,
         details: Faker::Hacker.say_something_smart,
         pitch: Faker::Superhero.power,
-        research: Faker::Lorem.sentence,
+        talk_type: Proposal::TALK_TYPES.sample,
         location_and_time_zone: Time.zone_default,
         equipment_requirements: Faker::Lorem.sentence,
         accessibility_requirements: Faker::Lorem.sentence,

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -44,7 +44,7 @@ describe ProposalsController, type: :controller do
           details: proposal.details,
           pitch: proposal.pitch,
           session_format_id: proposal.session_format.id,
-          # research: proposal.research,
+          talk_type: proposal.talk_type,
           location_and_time_zone: proposal.location_and_time_zone,
           equipment_requirements: proposal.equipment_requirements,
           accessibility_requirements: proposal.accessibility_requirements,

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -44,7 +44,7 @@ describe ProposalsController, type: :controller do
           details: proposal.details,
           pitch: proposal.pitch,
           session_format_id: proposal.session_format.id,
-          research: proposal.research,
+          # research: proposal.research,
           location_and_time_zone: proposal.location_and_time_zone,
           equipment_requirements: proposal.equipment_requirements,
           accessibility_requirements: proposal.accessibility_requirements,

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     details { "Various other things" }
     pitch { "Baseball." }
     session_format { SessionFormat.first || FactoryBot.create(:session_format) }
-    research { "Science" }
     location_and_time_zone { "Central Time (US & Canada)" }
     equipment_requirements { "Video camera" }
     accessibility_requirements { "None" }

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -15,7 +15,7 @@ feature "Proposals" do
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am awesome."
     fill_in 'Fit', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
-    # fill_in 'Research', with: "Some in depth research"
+    select 'Hybrid', from: 'Talk type'
     select '(GMT-06:00) Central Time (US & Canada)', from: "Location and time zone"
     fill_in 'Equipment requirements', with: "Lights, camera, action"
     fill_in 'Accessibility requirements', with: "None needed"

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -15,7 +15,7 @@ feature "Proposals" do
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am awesome."
     fill_in 'Fit', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Problem', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
-    fill_in 'Research', with: "Some in depth research"
+    # fill_in 'Research', with: "Some in depth research"
     select '(GMT-06:00) Central Time (US & Canada)', from: "Location and time zone"
     fill_in 'Equipment requirements', with: "Lights, camera, action"
     fill_in 'Accessibility requirements', with: "None needed"


### PR DESCRIPTION
## Description

This PR hides the 'Research' field from CFPs (but keeps historical submission's research fields available in the database) and adds a required 'Talk Type' field

## Related Issues

closes https://github.com/forem/cfp-app/issues/30
closes https://github.com/forem/cfp-app/issues/31

## Screenshots
<img width="996" alt="CleanShot 2022-02-18 at 08 43 36@2x" src="https://user-images.githubusercontent.com/37842/154704740-ff318f8e-7162-4b30-a049-0884b2d2a80a.png">
<img width="310" alt="CleanShot 2022-02-18 at 08 43 45@2x" src="https://user-images.githubusercontent.com/37842/154704747-4870e686-aafb-4334-87cb-d455b675b875.png">
<img width="1072" alt="CleanShot 2022-02-18 at 08 44 16@2x" src="https://user-images.githubusercontent.com/37842/154704755-2a94771b-e56d-416e-b97b-8460a5bb3d73.png">


## Important GIF

![alt text](https://media.giphy.com/media/ueLmlyAcoqFpePinUd/giphy.gif)