### PR TITLE
Remove abstract limit

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -27,7 +27,6 @@ class Proposal < ApplicationRecord
   ].freeze
 
   validates :title, :abstract, :session_format, presence: true
-  validate :abstract_length
   validates :title, length: { maximum: 60 }
   validates_inclusion_of :state, in: valid_states, allow_nil: true, message: "'%{value}' not a valid state."
   validates_inclusion_of :state, in: FINAL_STATES, allow_nil: false, message: "'%{value}' not a confirmable state.",
@@ -264,12 +263,6 @@ class Proposal < ApplicationRecord
   end
 
   private
-
-  def abstract_length
-    return unless abstract_changed? && abstract.gsub(/\r/, '').gsub(/\n/, '').length > 600
-
-    errors.add(:abstract, 'is too long (maximum is 600 characters)')
-  end
 
   def save_tags
     update_tags(proposal_taggings, @tags, false) if @tags

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -57,9 +57,9 @@ describe Proposal do
       expect{proposal.save}.to change{proposal.uuid}.from(nil).to('greendalec')
     end
 
-    it "limits abstracts to 600 characters or less" do
+    it "does not limit abstracts to 600 characters or less" do #This is a change from upstream rubycentral!
       expect(build(:proposal, abstract: "S" * 600)).to be_valid
-      expect(build(:proposal, abstract: "S" * 601)).not_to be_valid
+      expect(build(:proposal, abstract: "S" * 601)).to be_valid
     end
   end
 


### PR DESCRIPTION
## Description

As per https://github.com/forem/cfp-app/issues/34, this PR removes the 600-ish character limit on abstracts.

## Related PRs/Issues:

closes https://github.com/forem/cfp-app/issues/34

## Important GIF

![Unlimited!](https://media.giphy.com/media/3ohfFy2dgbPvVoAeKA/giphy.gif)