### PR TITLE
Remove frontend abstract limit of 1005 characters

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -174,7 +174,7 @@ class ProposalDecorator < ApplicationDecorator
 
   def abstract_input(form, tooltip = "Talk Outline")
     form.input :abstract, label: "Talk Outline",
-      maxlength: 1005, input_html: { class: 'watched js-maxlength-alert', rows: 5 },
+      input_html: { rows: 5 },
       hint: 'This is the place to outline the specifics of your talk: what topics will you cover, if you\'ll have any special elements (i.e., code samples, video samples, etc.), what you\'d like the audience to take away from your talk, and how you\'d like them to feel afterwards.'#, popover_icon: { content: tooltip }
   end
 

--- a/app/views/staff/program_sessions/_form.html.haml
+++ b/app/views/staff/program_sessions/_form.html.haml
@@ -6,7 +6,7 @@
       = f.association :track, as: :select, collection: current_event.tracks, label: "Theme", include_blank: true
       - unless @program_session.new_record?
         = f.input :state, as: :select, collection: session_states_collection, label: "State", required: true
-      = f.input :abstract, maxlength: 1205, input_html: { class: 'watched js-maxlength-alert', rows: 5 }, label: "Talk Outline"
+      = f.input :abstract, input_html: { rows: 5 }, label: "Talk Outline"
       = f.label :video_url
       = f.text_field :video_url, class: "form-control"
       = f.label :slides_url


### PR DESCRIPTION
This PR removes the random bits of the frontend code that were limiting talk abstracts to 1005 characters (even though the database limit was 600 - it was done to account for whitespace).

Closes https://github.com/forem/cfp-app/issues/34